### PR TITLE
Add interface for $

### DIFF
--- a/src/main/scala/org/scalajs/jquery/package.scala
+++ b/src/main/scala/org/scalajs/jquery/package.scala
@@ -4,4 +4,5 @@ import scala.scalajs.js
 
 package object jquery extends js.GlobalScope {
   val jQuery: JQueryStatic = ???
+  val $: JQueryStatic = ???
 }


### PR DESCRIPTION
I'm not sure if this is intended or not, there is no interface for [`$`](http://api.jquery.com/jquery/). I think every jQuery users will use `$` rather than long named `jQuery`. As I tested, it seems like `$` works fine.

If not to have the interface for `$` is intended because of Scala.js's limitation (something like name-mangling?), I'll just close this PR.
